### PR TITLE
Bump chisel to 3.2.1 snapshot and firrtl 1.2.1

### DIFF
--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,11 +1,11 @@
 [
     {
-        "commit": "d1a61262630b5ea77ebe21a453df9645cb7e4185",
+        "commit": "4bc1ee8c22a267c59750f1dfe08659f4130c83d3",
         "name": "chisel3",
         "source": "git@github.com:freechipsproject/chisel3.git"
     },
     {
-        "commit": "4977bbeeadc350e2e1290237d17dd1baf77013f8",
+        "commit": "0caa651a51fc9e6db71217fa5ab1e795e35cd4fa",
         "name": "api-firrtl-sifive",
         "source": "git@github.com:sifive/api-firrtl-sifive.git"
     }

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -1,6 +1,6 @@
 [
     {
-        "commit": "4bc1ee8c22a267c59750f1dfe08659f4130c83d3",
+        "commit": "f31e8bf4a591703a9541e18d608e4610470fa8a7",
         "name": "chisel3",
         "source": "git@github.com:freechipsproject/chisel3.git"
     },


### PR DESCRIPTION
This bumps the version of chisel that this repo points to to 3.2.1 plus one more commit beyond that (https://github.com/freechipsproject/chisel3/commit/f31e8bf4a591703a9541e18d608e4610470fa8a7), since we want the patch from that fix but didn't manage to get that out in time for the 3.2.1 release.

This also points to https://github.com/sifive/api-firrtl-sifive/pull/10, so I'll need to rebase this once that PR merges in.

Note that I also haven't done a full integration test of that yet.