### PR TITLE
Use published location for chisel3 repository, if available

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         arguments: |
           ${{ env.WIT_WORKSPACE }}
           -a ./wit-packages/api-chisel3-sifive
-          -a git@github.com:sifive/environment-blockci-sifive.git::0.3.0
+          -a git@github.com:sifive/environment-blockci-sifive.git::0.4.0
         force_github_https: true
 
     - name: Run tests
@@ -31,5 +31,5 @@ jobs:
           --volume="$GITHUB_WORKSPACE/$WIT_WORKSPACE:/mnt/workspace" \
           --workdir="/mnt/workspace" \
           --rm \
-          sifive/environment-blockci:0.3.0 \
+          sifive/environment-blockci:0.4.0 \
           api-chisel3-sifive/tests/run-tests.sh

--- a/build.wake
+++ b/build.wake
@@ -1,3 +1,13 @@
+global topic chisel3Root: String
+def chisel3Root =
+  def paths = subscribe chisel3Root
+  match (head paths)
+    Some path  =
+      if (len paths) != 1 then
+        panic "Multiple published paths for chisel3 root: {format paths}"
+      else
+        path
+    None = "chisel3" # default path in workspace
 
 def buildDir = mkdir "build/chisel3"
 
@@ -27,13 +37,13 @@ global def addMacrosParadiseCompilerPlugin module =
 
 global def chisel3CoreMacros =
   makeScalaModuleFromJSON here "chisel3Macros"
-  | setScalaModuleRootDir "chisel3/macros"
+  | setScalaModuleRootDir "{chisel3Root}/macros"
   | setScalaModuleScalacOptions scalacOpts
   | addMacrosParadiseCompilerPlugin
 
 global def chisel3Frontend =
   makeScalaModuleFromJSON here "chisel3Core"
-  | setScalaModuleRootDir "chisel3/core"
+  | setScalaModuleRootDir "{chisel3Root}/core"
   | setScalaModuleDeps (chisel3CoreMacros, firrtlScalaModule, Nil)
   | setScalaModuleScalacOptions scalacOpts
   | addMacrosParadiseCompilerPlugin
@@ -60,7 +70,7 @@ def buildInfo ver =
 global def chisel3ScalaModule =
   def base =
     makeScalaModuleFromJSON here "chisel3"
-    | setScalaModuleRootDir "chisel3"
+    | setScalaModuleRootDir chisel3Root
     | setScalaModuleDeps (chisel3Frontend, Nil)
     | setScalaModuleScalacOptions scalacOpts
     | addMacrosParadiseCompilerPlugin

--- a/build.wake
+++ b/build.wake
@@ -1,13 +1,10 @@
 global topic chisel3Root: String
 def chisel3Root =
   def paths = subscribe chisel3Root
-  match (head paths)
-    Some path  =
-      if (len paths) != 1 then
-        panic "Multiple published paths for chisel3 root: {format paths}"
-      else
-        path
-    None = "chisel3" # default path in workspace
+  match paths
+    Nil = "chisel3" # default path in workspace
+    path, Nil = path
+    _ = panic "Multiple published paths for chisel3 root: {format paths}"
 
 def buildDir = mkdir "build/chisel3"
 


### PR DESCRIPTION
Add a mechanism to subscribe to a location for the chisel3 repository.

I was looking to add a wake `here` self-location variable to chisel3, but it's not a sifive repository, so I've presumed that it wouldn't be appropriate to add it there. If it is, let me know and I'll submit a PR there
