### PR TITLE
Use indirection for chisel3 root path

### DIFF
--- a/build.wake
+++ b/build.wake
@@ -3,6 +3,8 @@ def buildDir = mkdir "build/chisel3"
 
 def scalacOpts = "-deprecation", "-feature", Nil
 
+def chisel3Root = findGitRepositoryWithFallback "chisel3"
+
 # We ignore scalaVersion because it comes from ScalaModule
 # The scalaVersion in ivydependencies.json is purely for fetching
 def macrosParadiseIvyDep =
@@ -27,13 +29,13 @@ global def addMacrosParadiseCompilerPlugin module =
 
 global def chisel3CoreMacros =
   makeScalaModuleFromJSON here "chisel3Macros"
-  | setScalaModuleRootDir "chisel3/macros"
+  | setScalaModuleRootDir "{chisel3Root}/macros"
   | setScalaModuleScalacOptions scalacOpts
   | addMacrosParadiseCompilerPlugin
 
 global def chisel3Frontend =
   makeScalaModuleFromJSON here "chisel3Core"
-  | setScalaModuleRootDir "chisel3/core"
+  | setScalaModuleRootDir "{chisel3Root}/core"
   | setScalaModuleDeps (chisel3CoreMacros, firrtlScalaModule, Nil)
   | setScalaModuleScalacOptions scalacOpts
   | addMacrosParadiseCompilerPlugin
@@ -60,7 +62,7 @@ def buildInfo ver =
 global def chisel3ScalaModule =
   def base =
     makeScalaModuleFromJSON here "chisel3"
-    | setScalaModuleRootDir "chisel3"
+    | setScalaModuleRootDir chisel3Root
     | setScalaModuleDeps (chisel3Frontend, Nil)
     | setScalaModuleScalacOptions scalacOpts
     | addMacrosParadiseCompilerPlugin

--- a/wit-manifest.json
+++ b/wit-manifest.json
@@ -8,5 +8,10 @@
         "commit": "72152a0b22610753397b057a056762aaedeabedd",
         "name": "api-firrtl-sifive",
         "source": "git@github.com:sifive/api-firrtl-sifive.git"
+    },
+    {
+        "commit": "1c3539138f71d38f007e19870bcf5f69d9713307",
+        "name": "api-scala-sifive",
+        "source": "git@github.com:sifive/api-scala-sifive.git"
     }
 ]


### PR DESCRIPTION
Find the chisel3 repository rather than using a hard-coded path.

Initially I was going to just bump api-firrtl as it was already a dependency, but I think this repo really should depend on api-scala as it directly uses symbols from api-scala beyond what this PR adds